### PR TITLE
feat: Update DecoratorsProcessor classname and version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 requires-python = ">=3.10"
 
 dependencies = [
-    "reqstool-python-decorators == 0.0.1", 
+    "reqstool-python-decorators == 0.0.2",
     "ruamel.yaml==0.18.6",
     "hatchling>=1.20.0",
 ]

--- a/src/reqstool_python_hatch_plugin/build_hook/hook.py
+++ b/src/reqstool_python_hatch_plugin/build_hook/hook.py
@@ -2,7 +2,7 @@
 
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
-from reqstool_python_decorators.processors.decorator_processor import ProcessDecorator
+from reqstool_python_decorators.processors.decorator_processor import DecoratorProcessor
 
 
 class Decorator(BuildHookInterface):
@@ -56,5 +56,5 @@ class Decorator(BuildHookInterface):
         """
         path = self.get_config_path
 
-        process_decorator = ProcessDecorator()
-        process_decorator.process_decorated_data(path_to_python_files=path)
+        decorator_processor = DecoratorProcessor()
+        decorator_processor.process_decorated_data(path_to_python_files=path)


### PR DESCRIPTION
Update with changes made to reqstool-python-decorators.

Classname, version in pyproject.toml and remove dir creation from plugin as it has been moved to the decorators repo.