### PR TITLE
feat(reqstool): dogfood OpenSpec <-> reqstool traceability

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "extraKnownMarketplaces": {
+    "reqstool-ai": {
+      "source": {
+        "source": "github",
+        "repo": "reqstool/reqstool-ai"
+      },
+      "autoUpdate": true
+    }
+  },
+  "enabledPlugins": {
+    "reqstool@reqstool-ai": true,
+    "reqstool-openspec@reqstool-ai": true
+  }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,9 @@ on:
       - reopened
       - synchronize
 
+permissions:
+  contents: read
+
 jobs:
   linting:
     name: Reuse linting job
@@ -19,6 +22,10 @@ jobs:
   build:
     needs: linting
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        reqstool-source: [pypi, main]
     steps:
       - name: Check out source repository
         uses: actions/checkout@v6
@@ -36,9 +43,31 @@ jobs:
         run: hatch run dev:pytest --junitxml=build/junit.xml --cov=reqstool_python_hatch_plugin --cov-report=xml:build/coverage.xml
       - name: Build project
         run: hatch build
+      - name: Self-apply own decorators to own src/tests
+        run: hatch run dev:python scripts/generate_annotations.py
+      - name: Install reqstool
+        uses: reqstool/.github/.github/actions/install-reqstool@74cc3ac55a476258898db82c69a78eeaabb2fcbc # main 2026-06-24
+        with:
+          reqstool-source: ${{ matrix.reqstool-source }}
+      - name: Validate reqstool spec completeness
+        # not yet available in the latest PyPI release; supplementary to (not a
+        # replacement for) the `reqstool status --fail-if-incomplete` gate below, which
+        # is the actual required check on the pypi leg
+        if: matrix.reqstool-source == 'main'
+        uses: reqstool/.github/.github/actions/validate-reqstool@74cc3ac55a476258898db82c69a78eeaabb2fcbc # main 2026-06-24
+      - name: Run reqstool status
+        # Required gate on both matrix legs -- fails the build unless every
+        # requirement is implemented and verified.
+        uses: reqstool/.github/.github/actions/reqstool-status@74cc3ac55a476258898db82c69a78eeaabb2fcbc # main 2026-06-24
+        with:
+          fail-if-incomplete: "true"
       # Upload artifacts for later use
       - name: Upload Artifacts
+        if: matrix.reqstool-source == 'pypi'
         uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/
+
+  validate-openspec:
+    uses: reqstool/.github/.github/workflows/common-validate-openspec.yml@74cc3ac55a476258898db82c69a78eeaabb2fcbc # main 2026-06-24

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,9 @@ jobs:
         run: hatch build
       - name: Self-apply own decorators to own src/tests
         run: hatch run dev:python scripts/generate_annotations.py
+      # NOTE: all reqstool/.github refs below are pinned to the same commit -- keep
+      # these 4 in sync when bumping (install-reqstool, validate-reqstool,
+      # reqstool-status, and the validate-openspec job's workflow ref further down).
       - name: Install reqstool
         uses: reqstool/.github/.github/actions/install-reqstool@74cc3ac55a476258898db82c69a78eeaabb2fcbc # main 2026-06-24
         with:
@@ -52,7 +55,7 @@ jobs:
       - name: Validate reqstool spec completeness
         # not yet available in the latest PyPI release; supplementary to (not a
         # replacement for) the `reqstool status --fail-if-incomplete` gate below, which
-        # is the actual required check on the pypi leg
+        # is the actual required check, run unconditionally on both matrix legs
         if: matrix.reqstool-source == 'main'
         uses: reqstool/.github/.github/actions/validate-reqstool@74cc3ac55a476258898db82c69a78eeaabb2fcbc # main 2026-06-24
       - name: Run reqstool status

--- a/.gitignore
+++ b/.gitignore
@@ -283,4 +283,5 @@ pyrightconfig.json
 # End of https://www.toptal.com/developers/gitignore/api/python,intellij+all,visualstudiocode
 
 # Claude Code
-.claude/
+.claude/*
+!.claude/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 build/
+!tests/fixtures/test_project/build/
 develop-eggs/
 dist/
 downloads/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "reqstool": {
+      "command": "reqstool",
+      "args": ["mcp"]
+    }
+  }
+}

--- a/.reqstool-ai.yaml
+++ b/.reqstool-ai.yaml
@@ -1,0 +1,32 @@
+# reqstool-ai configuration
+#
+# This file tells reqstool-ai skills where to find your reqstool files
+# and how to generate IDs for new requirements and SVCs.
+#
+# Place this file at: .reqstool-ai.yaml (project root)
+
+# Project URN — matches the urn in your reqstool YAML files
+urn: reqstool-python-hatch-plugin
+
+# Revision string for new requirements and SVCs
+revision: "0.1.0"
+
+# System-level reqstool directory (contains the SSOT requirements and SVCs)
+system:
+  path: docs/reqstool
+
+# Subproject modules — each module imports a subset of requirements/SVCs via filters
+#
+# Required fields per module:
+#   path       — path to the module's reqstool directory (contains filter files)
+#   req_prefix — prefix for requirement IDs belonging to this module (e.g., CORE_)
+#   svc_prefix — prefix for SVC IDs belonging to this module (e.g., SVC_CORE_)
+#
+# Add as many modules as your project has. The module name (key) is used in
+# commands like `/reqstool:status core` and `/reqstool:add-req core`.
+modules:
+  # Matches the existing HATCH_PLUGIN_NNN / SVC_HATCH_PLUGIN_NNN ID convention.
+  plugin:
+    path: docs/reqstool
+    req_prefix: "HATCH_PLUGIN_"
+    svc_prefix: "SVC_HATCH_PLUGIN_"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,8 @@ For DCO sign-off, commit conventions, and code review process, see the organizat
 
 - Python 3.13+
 - [Hatch](https://hatch.pypa.io/) (`pip install hatch`)
+- [reqstool](https://github.com/reqstool/reqstool-client) (`pipx install reqstool`)
+- [OpenSpec](https://github.com/Fission-AI/OpenSpec) (`npm install -g @fission-ai/openspec`)
 
 ## Setup
 
@@ -17,9 +19,32 @@ cd reqstool-python-hatch-plugin
 hatch env create
 ```
 
+If using Claude Code, opening this repo will prompt you to confirm adding the `reqstool-ai`
+marketplace and enabling the `reqstool`/`reqstool-openspec` plugins (configured in
+`.claude/settings.json`) — accept the prompt.
+
+Then regenerate the `opsx` slash commands and OpenSpec skills
+(`.claude/commands/opsx/`, `.claude/skills/openspec-*`) — they're CLI-generated tool scaffolding,
+not committed to the repo:
+
+```bash
+openspec update   # or: openspec init --tools claude --force
+```
+
 ## Build & Test
 
 ```bash
 hatch build
 hatch run test
+```
+
+## Self-applied traceability (`docs/reqstool/`)
+
+This project dogfoods itself: `hatch run dev:python scripts/generate_annotations.py` scans its
+own `src`/`tests/unit`/`tests/e2e` for `@Requirements`/`@SVCs` decorators and writes
+`build/reqstool/annotations.yml`. Check status with:
+
+```bash
+hatch build --target wheel && hatch run dev:pytest && hatch run dev:python scripts/generate_annotations.py
+reqstool status --check-all-reqs-met local -p docs/reqstool
 ```

--- a/docs/reqstool/reqstool_config.yml
+++ b/docs/reqstool/reqstool_config.yml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/reqstool_config.schema.json
+
+language: python
+build: hatch
+resources:
+  requirements: requirements.yml
+  software_verification_cases: software_verification_cases.yml
+  manual_verification_results: manual_verification_results.yml
+  annotations: ../../build/reqstool/annotations.yml
+  test_results:
+    - ../../build/**/*.xml

--- a/docs/reqstool/requirements.yml
+++ b/docs/reqstool/requirements.yml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/requirements.schema.json
+
+metadata:
+  urn: reqstool-python-hatch-plugin
+  variant: microservice
+  title: Reqstool Python Hatch Plugin
+  url: https://github.com/reqstool/reqstool-python-hatch-plugin
+
+requirements:
+  - id: HATCH_PLUGIN_001
+    title: Generate annotations.yml from reqstool decorators during build
+    significance: shall
+    description: >-
+      On `hatch build`, the plugin shall process the configured source
+      directories for `@Requirements`/`@SVCs` decorators and write the
+      result to annotations.yml in the configured output directory, before
+      any build artifact is produced.
+    categories: [functional-suitability]
+    revision: "0.1.0"
+  - id: HATCH_PLUGIN_002
+    title: Bundle reqstool dataset and annotations into the built sdist
+    significance: shall
+    description: >-
+      After a sdist artifact is built, the plugin shall append the
+      project's reqstool dataset (requirements.yml,
+      software_verification_cases.yml, manual_verification_results.yml,
+      when present), the generated annotations.yml, any configured test
+      result files, and a generated reqstool_config.yml directly into the
+      sdist tarball. Non-sdist artifacts (e.g. wheel) are left untouched.
+    categories: [functional-suitability]
+    revision: "0.1.0"

--- a/docs/reqstool/software_verification_cases.yml
+++ b/docs/reqstool/software_verification_cases.yml
@@ -1,0 +1,14 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/software_verification_cases.schema.json
+
+cases:
+  - id: SVC_HATCH_PLUGIN_001
+    requirement_ids: ["HATCH_PLUGIN_001"]
+    title: "Verify annotations.yml is generated from decorated source during hatch build"
+    verification: automated-test
+    revision: "0.1.0"
+
+  - id: SVC_HATCH_PLUGIN_002
+    requirement_ids: ["HATCH_PLUGIN_002"]
+    title: "Verify the built sdist tarball contains the reqstool dataset, annotations, and config"
+    verification: automated-test
+    revision: "0.1.0"

--- a/openspec/openspecui.hooks.ts
+++ b/openspec/openspecui.hooks.ts
@@ -1,0 +1,108 @@
+// @reqstool-openspec-hooks: 0.1.1
+import { spawn, ChildProcess } from "child_process";
+import type { OnReadDocumentHookV1 } from "openspecui/hooks";
+
+// Minimal MCP client over stdio (JSON-RPC 2.0, newline-delimited).
+// Uses only Node.js built-ins — no npm packages required.
+class McpStdioClient {
+  private proc: ChildProcess;
+  private buf = "";
+  private pending = new Map<
+    number,
+    { resolve: (v: unknown) => void; reject: (e: Error) => void }
+  >();
+  private id = 1;
+  readonly ready: Promise<void>;
+
+  constructor(cwd: string) {
+    this.proc = spawn("reqstool", ["mcp"], {
+      cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    this.proc.stdout!.on("data", (chunk: Buffer) => {
+      this.buf += chunk.toString();
+      let nl: number;
+      while ((nl = this.buf.indexOf("\n")) !== -1) {
+        const line = this.buf.slice(0, nl).trim();
+        this.buf = this.buf.slice(nl + 1);
+        if (line) this.handle(line);
+      }
+    });
+    this.ready = this.init();
+  }
+
+  private handle(line: string) {
+    try {
+      const msg = JSON.parse(line) as { id?: number; result?: unknown; error?: { message: string } };
+      if (msg.id !== undefined) {
+        const p = this.pending.get(msg.id);
+        if (p) {
+          this.pending.delete(msg.id);
+          msg.error ? p.reject(new Error(msg.error.message)) : p.resolve(msg.result);
+        }
+      }
+    } catch (e) {
+      console.warn("[reqstool-openspec] Skipping non-JSON line from reqstool mcp:", e instanceof Error ? e.message : e);
+    }
+  }
+
+  private send(method: string, params: unknown, expectReply = true): Promise<unknown> {
+    if (!expectReply) {
+      this.proc.stdin!.write(JSON.stringify({ jsonrpc: "2.0", method, params }) + "\n");
+      return Promise.resolve();
+    }
+    const id = this.id++;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.proc.stdin!.write(JSON.stringify({ jsonrpc: "2.0", id, method, params }) + "\n");
+    });
+  }
+
+  private async init(): Promise<void> {
+    await this.send("initialize", {
+      protocolVersion: "2024-11-05",
+      capabilities: { tools: {} },
+      clientInfo: { name: "openspecui", version: "1.0" },
+    });
+    this.send("notifications/initialized", {}, false);
+  }
+
+  async enrich(content: string, preset: string): Promise<string> {
+    await this.ready;
+    const result = (await this.send("tools/call", {
+      name: "enrich_document",
+      arguments: { content, preset },
+    })) as { content: { text: string }[] };
+    return result.content[0].text;
+  }
+
+  close() {
+    this.proc.stdin?.end();
+    this.proc.kill();
+  }
+}
+
+let client: McpStdioClient | null = null;
+
+export const onReadDocument: OnReadDocumentHookV1 = async (ctx, read) => {
+  if (!client) {
+    client = new McpStdioClient(ctx.projectDir);
+    ctx.lifecycle.onDispose(() => {
+      client?.close();
+      client = null;
+    });
+  }
+
+  const result = await read();
+  const preset = `openspec:${ctx.document.kind}`;
+
+  try {
+    const enriched = await client.enrich(result.markdown, preset);
+    return { ...result, markdown: enriched, sourceLabel: `reqstool ${preset}` };
+  } catch (e) {
+    return {
+      ...result,
+      diagnostics: [{ level: "warning", message: `reqstool enrich failed: ${e}` }],
+    };
+  }
+};

--- a/openspec/specs/annotation-generation/spec.md
+++ b/openspec/specs/annotation-generation/spec.md
@@ -1,0 +1,15 @@
+# Annotation Generation Specification
+
+## Purpose
+
+Requirement and SVC content is owned by reqstool (single source of truth). This spec references
+reqstool requirement and SVC IDs only; titles and descriptions are injected at read time via
+`reqstool enrich` (or the openspecui hook). See `docs/reqstool/`.
+
+## Requirements
+
+### Requirement: HATCH_PLUGIN_001
+The system SHALL implement HATCH_PLUGIN_001.
+
+#### Scenario: SVC_HATCH_PLUGIN_001
+The system SHALL pass SVC_HATCH_PLUGIN_001.

--- a/openspec/specs/sdist-bundling/spec.md
+++ b/openspec/specs/sdist-bundling/spec.md
@@ -1,0 +1,15 @@
+# Sdist Bundling Specification
+
+## Purpose
+
+Requirement and SVC content is owned by reqstool (single source of truth). This spec references
+reqstool requirement and SVC IDs only; titles and descriptions are injected at read time via
+`reqstool enrich` (or the openspecui hook). See `docs/reqstool/`.
+
+## Requirements
+
+### Requirement: HATCH_PLUGIN_002
+The system SHALL implement HATCH_PLUGIN_002.
+
+#### Scenario: SVC_HATCH_PLUGIN_002
+The system SHALL pass SVC_HATCH_PLUGIN_002.

--- a/scripts/generate_annotations.py
+++ b/scripts/generate_annotations.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+# Copyright © LFV
+"""Self-apply reqstool-python-decorators' processor to this repo's own src/tests,
+producing build/reqstool/annotations.yml for `reqstool status` to consume."""
+
+from reqstool_python_decorators.processors.decorator_processor import DecoratorProcessor
+
+if __name__ == "__main__":
+    DecoratorProcessor().process_decorated_data(
+        # tests/fixtures holds a self-contained fixture project with its own decorated
+        # REQ_001/SVC_001, unrelated to this plugin's own requirements -- excluded so it
+        # doesn't pollute this repo's own traceability data.
+        # tests/integration is omitted entirely: it's currently just empty __init__.py
+        # stubs, add it back once real integration tests land there.
+        path_to_python_files=["src", "tests/unit", "tests/e2e"],
+        output_file="build/reqstool/annotations.yml",
+    )

--- a/src/reqstool_python_hatch_plugin/build_hooks/reqstool.py
+++ b/src/reqstool_python_hatch_plugin/build_hooks/reqstool.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional
 
 from hatchling.builders.hooks.plugin.interface import BuildHookInterface
 from hatchling.builders.plugin.interface import BuilderInterface
+from reqstool_python_decorators.decorators.decorators import Requirements
 from reqstool_python_decorators.processors.decorator_processor import DecoratorProcessor
 from ruamel.yaml import YAML
 
@@ -51,6 +52,7 @@ class ReqstoolBuildHook(BuildHookInterface):
         super().__init__(*args, **kwargs)
         self.__config_path: Optional[str] = None
 
+    @Requirements("HATCH_PLUGIN_001")
     def initialize(self, version: str, build_data: Dict[str, Any]) -> None:
         """
         Executes custom actions during the build process.
@@ -63,6 +65,7 @@ class ReqstoolBuildHook(BuildHookInterface):
 
         self._create_annotations_file()
 
+    @Requirements("HATCH_PLUGIN_002")
     def finalize(self, version: str, build_data: dict[str, Any], artifact_path: str) -> None:
 
         if artifact_path.endswith(".tar.gz"):

--- a/tests/e2e/reqstool_python_hatch_plugin/test_build_e2e.py
+++ b/tests/e2e/reqstool_python_hatch_plugin/test_build_e2e.py
@@ -13,64 +13,93 @@ FIXTURE_DIR = Path(__file__).parents[2] / "fixtures" / "test_project"
 DIST_DIR = Path(__file__).parents[3] / "dist"
 
 # The hatch plugin appends reqstool_config.yml to the tar.gz and generates
-# annotations.yml on disk. requirements.yml and software_verification_cases.yml
-# are included via the sdist include config (docs/reqstool/**).
+# annotations.yml on disk. requirements.yml, software_verification_cases.yml, and
+# manual_verification_results.yml are all included via the sdist include config
+# (docs/reqstool/**). The hook does NOT bundle the actual test-result XML files into
+# the tarball -- it only records the configured glob pattern as a reqstool_config.yml
+# resource (test results are transient CI artifacts, not shipped in the package).
 EXPECTED_IN_TARBALL = [
     "reqstool_config.yml",
     "requirements.yml",
     "software_verification_cases.yml",
+    "manual_verification_results.yml",
 ]
 
 
-@pytest.mark.e2e
-@SVCs("SVC_HATCH_PLUGIN_001", "SVC_HATCH_PLUGIN_002")
-def test_hatch_build_sdist_contains_reqstool_artifacts():
-    """hatch build (sdist) triggers the reqstool hook and bundles all artifacts.
+def _build_fixture_sdist(tmpdir: str) -> tuple[Path, Path]:
+    """Builds the fixture project's sdist via an isolated venv with the local plugin
+    wheel pre-installed (bypassing hatch's own build-env management, which can't
+    resolve `@ file://` hook dependencies reliably across pip/uv versions).
 
-    Runs hatchling directly inside an isolated venv that has the local plugin wheel
-    pre-installed, bypassing hatch's own build-env management (which can't resolve
-    @ file:// hook dependencies reliably across pip/uv versions).
+    Returns (tarball_path, project_dir).
     """
+    tmp_project = Path(tmpdir) / "test_project"
+    # Keep build/test-results/junit.xml (the committed test_results fixture the hook
+    # bundles into the sdist) but drop dist/__pycache__. ignore_patterns matches by
+    # basename anywhere in the tree, so "build/reqstool" can't be excluded this way
+    # without also matching docs/reqstool -- removed separately below instead.
+    shutil.copytree(FIXTURE_DIR, tmp_project, ignore=shutil.ignore_patterns("dist", "__pycache__"))
+    shutil.rmtree(tmp_project / "build" / "reqstool", ignore_errors=True)
+
+    venv_dir = Path(tmpdir) / "build-venv"
+    venv.create(str(venv_dir), with_pip=True)
+    python = str(venv_dir / "bin" / "python")
+
     wheels = sorted(DIST_DIR.glob("reqstool_python_hatch_plugin-*.whl"))
     if not wheels:
         pytest.skip("No local wheel found — run `hatch build --target wheel` first")
 
+    subprocess.run(
+        [python, "-m", "pip", "install", "--quiet", "hatchling", str(wheels[-1])],
+        check=True,
+    )
+
+    result = subprocess.run(
+        [python, "-m", "hatchling", "build", "--target", "sdist"],
+        cwd=tmp_project,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"hatchling build failed:\n{result.stderr}"
+
+    tarballs = sorted((tmp_project / "dist").glob("mypackage-*.tar.gz"))
+    assert tarballs, "No tarball found in dist/"
+
+    return tarballs[-1], tmp_project
+
+
+@pytest.mark.e2e
+@SVCs("SVC_HATCH_PLUGIN_001")
+def test_hatch_build_generates_annotations_yml():
+    """hatch build's `initialize` hook generates annotations.yml from decorated source,
+    independently of whether the sdist-bundling (`finalize`) hook also succeeds."""
     with tempfile.TemporaryDirectory() as tmpdir:
-        tmp_project = Path(tmpdir) / "test_project"
-        shutil.copytree(FIXTURE_DIR, tmp_project, ignore=shutil.ignore_patterns("dist", "build", "__pycache__"))
+        _, tmp_project = _build_fixture_sdist(tmpdir)
 
-        # Build an isolated venv with hatchling + the local plugin wheel.
-        # We call hatchling directly so we fully control what's installed.
-        venv_dir = Path(tmpdir) / "build-venv"
-        venv.create(str(venv_dir), with_pip=True)
-        python = str(venv_dir / "bin" / "python")
-
-        subprocess.run(
-            [python, "-m", "pip", "install", "--quiet", "hatchling", str(wheels[-1])],
-            check=True,
-        )
-
-        result = subprocess.run(
-            [python, "-m", "hatchling", "build", "--target", "sdist"],
-            cwd=tmp_project,
-            capture_output=True,
-            text=True,
-        )
-        assert result.returncode == 0, f"hatchling build failed:\n{result.stderr}"
-
-        tarballs = sorted((tmp_project / "dist").glob("mypackage-*.tar.gz"))
-        assert tarballs, "No tarball found in dist/"
-
-        with tarfile.open(tarballs[-1]) as tf:
-            names = tf.getnames()
-            for expected in EXPECTED_IN_TARBALL:
-                assert any(
-                    expected in n for n in names
-                ), f"{expected!r} missing from {tarballs[-1].name};\ngot: {names}"
-
-        # annotations.yml is generated on disk (not bundled in the tarball)
         annotations_file = tmp_project / "build" / "reqstool" / "annotations.yml"
         assert annotations_file.exists(), f"annotations.yml not generated at {annotations_file}"
         annotations_content = annotations_file.read_text()
         assert "REQ_001" in annotations_content, "annotations.yml missing REQ_001"
         assert "SVC_001" in annotations_content, "annotations.yml missing SVC_001"
+
+
+@pytest.mark.e2e
+@SVCs("SVC_HATCH_PLUGIN_002")
+def test_hatch_build_sdist_bundles_reqstool_dataset():
+    """hatch build's `finalize` hook bundles the full reqstool dataset -- including the
+    optional manual_verification_results.yml and configured test_results glob -- into
+    the sdist tarball, independently of whether annotation generation also succeeds."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tarball, _ = _build_fixture_sdist(tmpdir)
+
+        with tarfile.open(tarball) as tf:
+            names = tf.getnames()
+            for expected in EXPECTED_IN_TARBALL:
+                assert any(expected in n for n in names), f"{expected!r} missing from {tarball.name};\ngot: {names}"
+
+            config_member = next(n for n in names if n.endswith("reqstool_config.yml"))
+            config_fileobj = tf.extractfile(config_member)
+            assert config_fileobj is not None, f"{config_member!r} is not a regular file"
+            config_content = config_fileobj.read().decode()
+            assert "test_results" in config_content, "reqstool_config.yml missing test_results"
+            assert "junit.xml" in config_content, "reqstool_config.yml missing the configured test_results glob"

--- a/tests/e2e/reqstool_python_hatch_plugin/test_build_e2e.py
+++ b/tests/e2e/reqstool_python_hatch_plugin/test_build_e2e.py
@@ -7,6 +7,7 @@ import venv
 from pathlib import Path
 
 import pytest
+from reqstool_python_decorators.decorators.decorators import SVCs
 
 FIXTURE_DIR = Path(__file__).parents[2] / "fixtures" / "test_project"
 DIST_DIR = Path(__file__).parents[3] / "dist"
@@ -22,6 +23,7 @@ EXPECTED_IN_TARBALL = [
 
 
 @pytest.mark.e2e
+@SVCs("SVC_HATCH_PLUGIN_001", "SVC_HATCH_PLUGIN_002")
 def test_hatch_build_sdist_contains_reqstool_artifacts():
     """hatch build (sdist) triggers the reqstool hook and bundles all artifacts.
 

--- a/tests/fixtures/test_project/build/test-results/junit.xml
+++ b/tests/fixtures/test_project/build/test-results/junit.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="utf-8"?><testsuites name="pytest tests"><testsuite name="pytest" errors="0" failures="0" skipped="0" tests="1" time="0.009" timestamp="2026-03-03T21:13:14.848434+01:00" hostname="turing"><testcase classname="tests.test_main" name="test_hello" time="0.000" /></testsuite></testsuites>

--- a/tests/fixtures/test_project/docs/reqstool/manual_verification_results.yml
+++ b/tests/fixtures/test_project/docs/reqstool/manual_verification_results.yml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/reqstool/reqstool-client/main/src/reqstool/resources/schemas/v1/manual_verification_results.schema.json
+
+results:
+  - id: MVR_001
+    svc_ids: ["SVC_001"]
+    comment: Manually verified hello function returns hello.
+    pass: true


### PR DESCRIPTION
## Summary

Bootstraps the OpenSpec spec layer and derives the reqstool requirement traceability SSOT for this repo, mirroring [reqstool-client#407](https://github.com/reqstool/reqstool-client/pull/407), [reqstool-python-decorators#84](https://github.com/reqstool/reqstool-python-decorators/pull/84), and [reqstool-typescript-tags#113](https://github.com/reqstool/reqstool-typescript-tags/pull/113).

- `docs/reqstool/{requirements,software_verification_cases,reqstool_config}.yml` with 2 capability-prefixed requirements (`HATCH_PLUGIN_001`/`002`) covering annotation generation during build and sdist bundling. Only 2 capabilities vs. `reqstool-python-poetry-plugin`'s 5 — Hatch's build-hook model doesn't need a separate `pyproject.toml` include-registration step or a root-file-cleanup step; it appends directly into the already-built sdist tarball
- `openspec/specs/{annotation-generation,sdist-bundling}` thin ID-reference spec files
- Tagged `ReqstoolBuildHook.initialize`/`.finalize` with `@Requirements`; tagged the existing e2e test (`test_build_e2e.py`, the only test that meaningfully exercises the hook against a real hatchling build of a fixture project) with `@SVCs` for both capabilities
- `scripts/generate_annotations.py` self-applies the decorator processor to this repo's own `src`/`tests/unit`/`tests/e2e` — no chicken-and-egg problem, same as #84. `tests/fixtures` is excluded (its own self-contained fixture project has unrelated decorated `REQ_001`/`SVC_001`); `tests/integration` is empty stub packages, omitted until real tests land
- CI: new `[pypi, main]` matrix on the `build` job, then self-apply, `reqstool-status` (required gate), and `validate-reqstool` (main leg only, supplementary); new `validate-openspec` job
- `.claude/settings.json` + `.mcp.json` wire up the `reqstool-ai` plugins/MCP server

## Test plan

- [x] `hatch build --target wheel && hatch run dev:pytest && hatch build` — 1 passed / 1 skipped (pre-existing skip, unrelated to this PR)
- [x] `hatch run dev:python scripts/generate_annotations.py` — clean self-apply, no fixture-ID pollution
- [x] `reqstool validate --strict local -p docs/reqstool` — pass
- [x] `reqstool status --check-all-reqs-met local -p docs/reqstool` — 2/2 complete
- [x] CLI vs MCP (`reqstool mcp local -p docs/reqstool`, `get_requirements_status`) — agree
- [x] `openspec validate --specs --strict` — 2/2 pass